### PR TITLE
Specify python2.7 in shebang as this is required

### DIFF
--- a/gtest-parallel
+++ b/gtest-parallel
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
 # Copyright 2017 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Any system where python2 is actually python2.6 will fail to run this.